### PR TITLE
Ensure that \r never ends up in Windows output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 
 ### Fixed
 - Windows paths for cwd-based paths use the proper slash.
-
+- `clitest!` macro will print the real line number of the macro's embedding location.
 
 ## [0.4.7] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-06
+
+### Fixed
+- Windows paths for cwd-based paths use the proper slash.
+
+
 ## [0.4.7] - 2026-04-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Fixed
 - Windows paths for cwd-based paths use the proper slash.
 - `clitest!` macro will print the real line number of the macro's embedding location.
+- Ensure '\r' never ends up in output.
 
 ## [0.4.7] - 2026-04-27
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,10 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.4.7" # Update versions below as well
+version = "0.5.0" # Update versions below as well
 
 [workspace.dependencies]
-clitest-lib = { path = "crates/clitest-lib", version = "=0.4.7" }
+clitest-lib = { path = "crates/clitest-lib", version = "=0.5.0" }
 
 clap = "4.6.1"
 derive-io = "=0.5.0"

--- a/crates/clitest-integration/tests/integration_tests.rs
+++ b/crates/clitest-integration/tests/integration_tests.rs
@@ -219,7 +219,7 @@ fn check_output(test: &TestCase, output: String) -> bool {
         let comparison = pretty_assertions::StrComparison::new(&a, &b);
         println!("{comparison}");
         cprintln_rule!();
-        cprintln!("\nOriginal output before munge:");
+        cprintln!("\nOriginal output before munge (root = {root:?}):");
         cprintln_rule!();
         cprintln!("{}", output);
         cprintln_rule!();

--- a/crates/clitest-lib/Cargo.toml
+++ b/crates/clitest-lib/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../../README.md"
 
 [features]
 default = ["onig"]
+
 fancy-regex = ["grok/fancy-regex"]
 onig = ["grok/onig"]
 

--- a/crates/clitest-lib/src/command.rs
+++ b/crates/clitest-lib/src/command.rs
@@ -141,6 +141,9 @@ impl CommandLine {
                     if line.ends_with('\n') {
                         line.pop();
                     }
+                    if line.ends_with('\r') {
+                        line.pop();
+                    }
                     _ = stderr_lines.send((false, std::mem::take(&mut line)));
                 }
             });

--- a/crates/clitest-lib/src/command.rs
+++ b/crates/clitest-lib/src/command.rs
@@ -122,6 +122,9 @@ impl CommandLine {
                     if line.ends_with('\n') {
                         line.pop();
                     }
+                    if line.ends_with('\r') {
+                        line.pop();
+                    }
                     _ = stdout_lines.send((true, std::mem::take(&mut line)));
                 }
             });

--- a/crates/clitest-lib/src/lib.rs
+++ b/crates/clitest-lib/src/lib.rs
@@ -73,8 +73,14 @@ pub fn run_captured(script: &str) -> String {
 }
 
 /// Parse and run a clitest script string. Returns captured output. Panics on failure.
-pub fn run_with_path_captured(name: &str, path: impl AsRef<Path>, script: &str) -> String {
-    let file = ScriptFile::new(dunce::canonicalize(path.as_ref()).unwrap().join(name));
+pub fn run_with_path_captured(
+    name: &str,
+    line: usize,
+    path: impl AsRef<Path>,
+    script: &str,
+) -> String {
+    let file =
+        ScriptFile::new_with_line(dunce::canonicalize(path.as_ref()).unwrap().join(name), line);
     let parsed = match parser::parse_script(file, script) {
         Ok(s) => s,
         Err(e) => panic!("clitest parse error: {e}"),
@@ -173,6 +179,7 @@ macro_rules! clitest {
         fn $name() {
             let output = $crate::run_with_path_captured(
                 stringify!($name),
+                line!() as _,
                 std::env::current_dir().unwrap(),
                 &format!("#!/usr/bin/env clitest --v0\n{}", $script),
             );

--- a/crates/clitest-lib/src/script.rs
+++ b/crates/clitest-lib/src/script.rs
@@ -44,12 +44,20 @@ impl std::fmt::Display for ScriptLocation {
 )]
 #[display("{}", file)]
 pub struct ScriptFile {
+    pub base_line: usize,
     pub file: Arc<NicePathBuf>,
 }
 
 impl ScriptFile {
     pub fn new(file: impl AsRef<Path>) -> Self {
         Self {
+            base_line: 0,
+            file: Arc::new(NicePathBuf::new(file)),
+        }
+    }
+    pub fn new_with_line(file: impl AsRef<Path>, line: usize) -> Self {
+        Self {
+            base_line: line,
             file: Arc::new(NicePathBuf::new(file)),
         }
     }
@@ -726,7 +734,7 @@ impl ScriptLine {
             .lines()
             .enumerate()
             .map(|(line, text)| Self {
-                location: ScriptLocation::new(file.clone(), line + 1),
+                location: ScriptLocation::new(file.clone(), line + file.base_line + 1),
                 text: text.to_string(),
             })
             .collect()

--- a/crates/clitest-lib/src/util.rs
+++ b/crates/clitest-lib/src/util.rs
@@ -284,6 +284,9 @@ fn write_pretty_path(
         if debug {
             write_debug_path(f, path)?;
         } else {
+            #[cfg(windows)]
+            write!(f, ".\\{}", path.display())?;
+            #[cfg(not(windows))]
             write!(f, "./{}", path.display())?;
         }
         return Ok(());

--- a/doc/src/environment.md
+++ b/doc/src/environment.md
@@ -68,6 +68,7 @@ The working directory is managed through a special variable `PWD`. This can be s
 Change the current working directory. The `PWD` is updated to the new directory for the duration of the test, unless another command changes it:
 
 ```bash session
+$ mkdir "subdir";
 cd "subdir";
 ```
 

--- a/tests/v0/windows_line_ending.bin
+++ b/tests/v0/windows_line_ending.bin
@@ -1,0 +1,2 @@
+hello
+world

--- a/tests/v0/windows_line_ending.bin
+++ b/tests/v0/windows_line_ending.bin
@@ -1,2 +1,0 @@
-hello
-world

--- a/tests/v0/windows_line_ending.cli
+++ b/tests/v0/windows_line_ending.cli
@@ -1,0 +1,5 @@
+#!/usr/bin/env clitest --v0
+
+$ printf "hello\r\nworld\r\n"
+! hello
+! world

--- a/tests/v0/windows_line_ending.cli
+++ b/tests/v0/windows_line_ending.cli
@@ -1,5 +1,5 @@
 #!/usr/bin/env clitest --v0
 
-$ printf "hello\r\nworld\r\n"
+$ awk 'BEGIN{printf "hello\r\nworld\r\n"}' > windows_line_ending.bin; cat windows_line_ending.bin
 ! hello
 ! world

--- a/tests/v0/windows_line_ending.cli
+++ b/tests/v0/windows_line_ending.cli
@@ -1,5 +1,7 @@
 #!/usr/bin/env clitest --v0
 
+using tempdir;
+
 $ awk 'BEGIN{printf "hello\r\nworld\r\n"}' > windows_line_ending.bin; cat windows_line_ending.bin
 ! hello
 ! world

--- a/tests/v0/windows_line_ending.out
+++ b/tests/v0/windows_line_ending.out
@@ -1,6 +1,6 @@
 Running <root>/windows_line_ending.cli ...
 
-printf "hello\r\nworld\r\n"
+awk 'BEGIN{printf "hello\r\nworld\r\n"}' > windows_line_ending.bin; cat windows_line_ending.bin
 ---
 hello
 world

--- a/tests/v0/windows_line_ending.out
+++ b/tests/v0/windows_line_ending.out
@@ -1,10 +1,14 @@
 Running <root>/windows_line_ending.cli ...
 
+using tempdir: <tmp>
+
 awk 'BEGIN{printf "hello\r\nworld\r\n"}' > windows_line_ending.bin; cat windows_line_ending.bin
 ---
 hello
 world
 ---
 ✅ OK
+
+(cleanup) removing <tmp> && cd <root>
 
 <root>/windows_line_ending.cli PASSED

--- a/tests/v0/windows_line_ending.out
+++ b/tests/v0/windows_line_ending.out
@@ -1,4 +1,4 @@
-Running <root>/tests/v0/windows_line_ending.cli ...
+Running <root>/windows_line_ending.cli ...
 
 printf "hello\r\nworld\r\n"
 ---
@@ -7,4 +7,4 @@ world
 ---
 ✅ OK
 
-<root>/tests/v0/windows_line_ending.cli PASSED
+<root>/windows_line_ending.cli PASSED

--- a/tests/v0/windows_line_ending.out
+++ b/tests/v0/windows_line_ending.out
@@ -1,0 +1,10 @@
+Running <root>/tests/v0/windows_line_ending.cli ...
+
+printf "hello\r\nworld\r\n"
+---
+hello
+world
+---
+✅ OK
+
+<root>/tests/v0/windows_line_ending.cli PASSED


### PR DESCRIPTION
For some reason, we're seeing `\r` show up in some failing tests. Let's just remove them when the command is running, regardless of platform.