### PR TITLE
Improve pattern errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,7 +153,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clitest"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "clap",
  "clitest-lib",
@@ -171,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "clitest-lib"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "derive-io",
  "derive_more",
@@ -181,7 +187,9 @@ dependencies = [
  "grok",
  "humantime",
  "keepcalm",
+ "linktime",
  "pretty_assertions",
+ "scattered-collect",
  "serde",
  "shellish_parse",
  "signal-child",
@@ -342,6 +350,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
+]
+
+[[package]]
 name = "derive-io"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +434,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
+]
+
+[[package]]
+name = "dtor"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e84c00697eca0d99ddc657698f9238f7426bac392c5ea859f5efdfdd2b719dd7"
+dependencies = [
+ "linktime-proc-macro",
 ]
 
 [[package]]
@@ -634,6 +661,33 @@ checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "link-section"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a63f9687974de7e2caf6c96a1b19c6e882db299fdde09075c5b9e11c58421cd"
+dependencies = [
+ "linktime-proc-macro",
+]
+
+[[package]]
+name = "linktime"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24c0237789ca078da896c7e98f9f885790fa66c3214d5977a22718a261e1b74e"
+dependencies = [
+ "ctor",
+ "dtor",
+ "link-section",
+ "linktime-proc-macro",
+]
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
 
 [[package]]
 name = "linux-raw-sys"
@@ -910,6 +964,29 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "scattered-collect"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60c604f8b89c9d0cdf7f040cb9f50e83a81306ee6149b72682d59e76fafd4e5e"
+dependencies = [
+ "ctor",
+ "link-section",
+ "linktime",
+ "linktime-proc-macro",
+ "wide",
+ "xxhash-rust",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1364,6 +1441,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wide"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7714cd0430a663154667c74da5d09325c2387695bee18b3f7f72825aa3693a"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "widestring"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +1795,12 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,9 +96,9 @@ checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -655,9 +655,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -712,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "mdbook-core"
@@ -744,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "minimad"
@@ -759,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -1073,9 +1073,9 @@ checksum = "4c29b912ad681a28566f37b936bba1f3580a93b9391c4a0b12cb1c6b4ed79973"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-child"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,10 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.6.0" # Update versions below as well
+version = "0.7.0" # Update versions below as well
 
 [workspace.dependencies]
-clitest-lib = { path = "crates/clitest-lib", version = "=0.6.0" }
+clitest-lib = { path = "crates/clitest-lib", version = "0.7.0" }
 
 clap = "4.6.1"
 derive-io = "=0.5.0"
@@ -16,7 +16,9 @@ dunce = "1.0.5"
 grok = { version = "2.4.1", default-features = false }
 keepcalm = "0.4"
 humantime = "2.3"
-mdbook-preprocessor = "0.5"
+linktime = "0.17.0"
+scattered-collect = "0.10.0"
+mdbook-preprocessor = "0.5.3"
 pathdiff = "0.2.3"
 pretty_assertions = "1"
 semver = "1.0.27"

--- a/crates/clitest-integration/tests/integration_tests.rs
+++ b/crates/clitest-integration/tests/integration_tests.rs
@@ -149,6 +149,13 @@ fn munge_output(root: &str, s: &str) -> String {
 }
 
 fn munge_line(root: &str, tmp: &[&str], output: &mut String, line: &str) {
+    // Normalize ASCII fallbacks so expected output matches regardless of UTF-8 locale.
+    let line = line
+        .replace("[X] FAIL", "❌ FAIL")
+        .replace("[X]-", "❌-")
+        .replace("[*] OK", "✅ OK")
+        .replace(" -> ", " → ");
+
     // Windows/Unix differs here
     #[cfg(windows)]
     let line = line.replace("exit code", "exit status");

--- a/crates/clitest-lib/Cargo.toml
+++ b/crates/clitest-lib/Cargo.toml
@@ -33,6 +33,8 @@ derive-io.workspace = true
 dunce.workspace = true
 humantime.workspace = true
 fast-strip-ansi.workspace = true
+linktime.workspace = true
+scattered-collect.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/crates/clitest-lib/src/failure.rs
+++ b/crates/clitest-lib/src/failure.rs
@@ -1,17 +1,42 @@
+use std::borrow::Cow;
+
 use crate::{
     output::{Line, OutputPatternType},
     script::{IfCondition, ScriptLocation},
 };
 
 #[derive(Clone, Debug, thiserror::Error, derive_more::Display, PartialEq, Eq)]
-#[display("pattern {pattern_type} at line {location} {verb} output line {line:?}", verb = self.verb(), line = self.line())]
+#[display("{pattern_type} at line {location} {verb} {line}", verb = self.verb(), line = self.line())]
 pub struct OutputPatternMatchFailure {
-    pub location: ScriptLocation,
-    pub pattern_type: &'static str,
+    location: ScriptLocation,
+    pattern_type: Cow<'static, str>,
     pub output_line: Option<Line>,
+    pattern_label: Option<String>,
 }
 
 impl OutputPatternMatchFailure {
+    pub fn new(
+        location: &ScriptLocation,
+        line: Option<Line>,
+        pattern_type: &OutputPatternType,
+    ) -> Self {
+        Self {
+            location: location.clone(),
+            pattern_type: Cow::Owned(pattern_type.trace_string()),
+            output_line: line,
+            pattern_label: None,
+        }
+    }
+
+    pub fn new_reject(location: &ScriptLocation, line: Option<Line>) -> Self {
+        Self {
+            location: location.clone(),
+            pattern_type: Cow::Borrowed("reject"),
+            output_line: line,
+            pattern_label: None,
+        }
+    }
+
     fn verb(&self) -> &'static str {
         if self.pattern_type == "reject" {
             "rejected"
@@ -23,8 +48,8 @@ impl OutputPatternMatchFailure {
     fn line(&self) -> String {
         self.output_line
             .as_ref()
-            .map(|l| l.text.clone())
-            .unwrap_or("<eof>".to_string())
+            .map(|l| format!("output line {:?}", l.text))
+            .unwrap_or("output".to_string())
     }
 }
 

--- a/crates/clitest-lib/src/output.rs
+++ b/crates/clitest-lib/src/output.rs
@@ -100,11 +100,10 @@ impl Lines {
                         .matches(context.ignore(), ignore_check.clone())
                         .is_ok()
                     {
-                        return Err(OutputPatternMatchFailure {
-                            location: rejected_pattern.location.clone(),
-                            pattern_type: "reject",
-                            output_line: next.next_line(),
-                        });
+                        return Err(OutputPatternMatchFailure::new_reject(
+                            &rejected_pattern.location,
+                            next.next_line(),
+                        ));
                     }
                 }
             }
@@ -349,7 +348,7 @@ impl Serialize for OutputPatternType {
                 serializer.serialize_str(&format!("! {literal}"))
             }
             OutputPatternType::Pattern(pattern) => {
-                serializer.serialize_str(&format!("? {}", pattern.pattern))
+                serializer.serialize_str(&pattern.display_source())
             }
             OutputPatternType::Repeat(pattern) => {
                 HashMap::from([("repeat", &pattern)]).serialize(serializer)
@@ -496,6 +495,12 @@ impl OutputPatternType {
             OutputPatternType::End => {
                 write!(out, "<eof>")
             }
+            OutputPatternType::Pattern(pattern) => {
+                write!(out, "pattern {:?}", pattern.display_source())
+            }
+            OutputPatternType::Literal(literal) => {
+                write!(out, "{literal:?}")
+            }
             _ if self.is_container() => {
                 write!(out, "{} {{ ... }}", self.keyword())
             }
@@ -537,6 +542,7 @@ impl std::fmt::Debug for OutputPatternType {
 #[derive(Serialize, derive_more::Debug)]
 #[debug("/{pattern:?}/")]
 pub struct GrokPattern {
+    original: String,
     pattern: String,
     aliases: Vec<String>,
     #[serde(skip)]
@@ -544,7 +550,11 @@ pub struct GrokPattern {
 }
 
 impl GrokPattern {
-    pub fn compile(line: &str, escape_non_grok: bool) -> Result<Self, String> {
+    pub fn display_source(&self) -> &str {
+        &self.original
+    }
+
+    pub fn compile(line: &str, original: String, escape_non_grok: bool) -> Result<Self, String> {
         use grok::parser::GrokPatternError;
         let mut test_pattern = String::new();
         let mut final_pattern = String::new();
@@ -600,6 +610,7 @@ impl GrokPattern {
             .map_err(|e| e.to_string())?;
 
         Ok(Self {
+            original,
             pattern: final_pattern,
             aliases,
             grok: OnceLock::new(),
@@ -876,14 +887,7 @@ impl OutputPatternType {
             OutputPatternType::Literal(literal) => {
                 let (line, next) = output.next(context.clone()).map_err(RawPatternErr::from)?;
                 let Some(line) = line else {
-                    return raw_err(
-                        OutputPatternMatchFailure {
-                            location: location.clone(),
-                            pattern_type: "literal",
-                            output_line: None,
-                        },
-                        None,
-                    );
+                    return raw_err(OutputPatternMatchFailure::new(location, None, self), None);
                 };
                 let text = line.text.trim_end();
                 if text == literal
@@ -893,11 +897,7 @@ impl OutputPatternType {
                     raw_ok(next, Some(line.clone()))
                 } else {
                     raw_err(
-                        OutputPatternMatchFailure {
-                            location: location.clone(),
-                            pattern_type: "literal",
-                            output_line: Some(line.clone()),
-                        },
+                        OutputPatternMatchFailure::new(location, Some(line), self),
                         None,
                     )
                 }
@@ -905,14 +905,7 @@ impl OutputPatternType {
             OutputPatternType::Pattern(pattern) => {
                 let (line, next) = output.next(context.clone()).map_err(RawPatternErr::from)?;
                 let Some(line) = line else {
-                    return raw_err(
-                        OutputPatternMatchFailure {
-                            location: location.clone(),
-                            pattern_type: "pattern",
-                            output_line: None,
-                        },
-                        None,
-                    );
+                    return raw_err(OutputPatternMatchFailure::new(location, None, self), None);
                 };
                 let mut text = line.text.clone();
                 let mut res = pattern.matches(&text);
@@ -925,11 +918,7 @@ impl OutputPatternType {
                 }
                 match res {
                     None => raw_err(
-                        OutputPatternMatchFailure {
-                            location: location.clone(),
-                            pattern_type: "pattern",
-                            output_line: Some(line.clone()),
-                        },
+                        OutputPatternMatchFailure::new(location, Some(line), self),
                         None,
                     ),
                     Some(matches) => {
@@ -944,11 +933,7 @@ impl OutputPatternType {
                                     && existing != value
                                 {
                                     return raw_err(
-                                        OutputPatternMatchFailure {
-                                            location: location.clone(),
-                                            pattern_type: "pattern",
-                                            output_line: Some(line.clone()),
-                                        },
+                                        OutputPatternMatchFailure::new(location, Some(line), self),
                                         Some(PatternTraceNote::AliasMismatch(
                                             existing,
                                             value.to_string(),
@@ -1011,11 +996,7 @@ impl OutputPatternType {
                         }
                     }
                     return raw_err(
-                        OutputPatternMatchFailure {
-                            location: location.clone(),
-                            pattern_type: "unordered",
-                            output_line: output.next_line(),
-                        },
+                        OutputPatternMatchFailure::new(location, output.next_line(), self),
                         None,
                     );
                 }
@@ -1032,11 +1013,7 @@ impl OutputPatternType {
                     }
                 }
                 raw_err(
-                    OutputPatternMatchFailure {
-                        location: location.clone(),
-                        pattern_type: "choice",
-                        output_line: output.next_line(),
-                    },
+                    OutputPatternMatchFailure::new(location, output.next_line(), self),
                     None,
                 )
             }
@@ -1045,11 +1022,7 @@ impl OutputPatternType {
                     raw_ok(output, None)
                 } else {
                     raw_err(
-                        OutputPatternMatchFailure {
-                            location: location.clone(),
-                            pattern_type: "not",
-                            output_line: output.next_line(),
-                        },
+                        OutputPatternMatchFailure::new(location, output.next_line(), self),
                         None,
                     )
                 }
@@ -1094,11 +1067,7 @@ impl OutputPatternType {
                 let (line, next) = output.next(context.clone()).map_err(RawPatternErr::from)?;
                 if let Some(line) = line {
                     raw_err(
-                        OutputPatternMatchFailure {
-                            location: location.clone(),
-                            pattern_type: "end",
-                            output_line: Some(line),
-                        },
+                        OutputPatternMatchFailure::new(location, Some(line), self),
                         None,
                     )
                 } else {

--- a/crates/clitest-lib/src/parser/v0/parse.rs
+++ b/crates/clitest-lib/src/parser/v0/parse.rs
@@ -458,6 +458,7 @@ fn parse_pattern_line(
     }
 
     let text = text.trim_end();
+    let original = text.to_string();
 
     if line_start == '!' {
         if !text.contains("%") {
@@ -469,7 +470,7 @@ fn parse_pattern_line(
             });
         }
 
-        let pattern = GrokPattern::compile(text, true).map_err(|e| {
+        let pattern = GrokPattern::compile(text, original, true).map_err(|e| {
             ScriptError::new_with_data(
                 ScriptErrorType::InvalidPattern,
                 location.clone(),
@@ -488,7 +489,7 @@ fn parse_pattern_line(
         } else {
             format!(r#"^{text}\s*$"#)
         };
-        let pattern = GrokPattern::compile(&text, false).map_err(|e| {
+        let pattern = GrokPattern::compile(&text, original, false).map_err(|e| {
             ScriptError::new_with_data(
                 ScriptErrorType::InvalidPattern,
                 location.clone(),

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "clitest";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = ./.;
 

--- a/tests/v0-fail/any.out
+++ b/tests/v0-fail/any.out
@@ -26,7 +26,7 @@ Excepteur sint occaecat cupidatat non
 proident, sunt in culpa qui officia
 deserunt mollit anim id est laborum.
 ---
-ERROR: pattern literal at line <root>/any.cli:19 does not match output line "<eof>"
+ERROR: "proident, sunt in culpa qui officiaX" at line <root>/any.cli:19 does not match output
 [XX] missed sequence { ... }
   [OK] matched "Lorem ipsum dolor sit amet,"
   [OK] matched * ... "ullamco laboris nisi ut aliquip ex ea"
@@ -47,5 +47,5 @@ ERROR: pattern literal at line <root>/any.cli:19 does not match output line "<eo
 ❌ FAIL
 
 <root>/any.cli FAILED
-Error: pattern literal at line <root>/any.cli:19 does not match output line "<eof>"
+Error: "proident, sunt in culpa qui officiaX" at line <root>/any.cli:19 does not match output
 

--- a/tests/v0-fail/choice.out
+++ b/tests/v0-fail/choice.out
@@ -4,7 +4,7 @@ printf "hello\n"
 ---
 hello
 ---
-ERROR: pattern choice at line <root>/choice.cli:4 does not match output line "hello"
+ERROR: choice { ... } at line <root>/choice.cli:4 does not match output line "hello"
 [XX] missed sequence { ... }
   [XX] missed choice { ... }
     [XX] missed "foo" != "hello"
@@ -14,5 +14,5 @@ ERROR: pattern choice at line <root>/choice.cli:4 does not match output line "he
 ❌ FAIL
 
 <root>/choice.cli FAILED
-Error: pattern choice at line <root>/choice.cli:4 does not match output line "hello"
+Error: choice { ... } at line <root>/choice.cli:4 does not match output line "hello"
 

--- a/tests/v0-fail/complex_pattern_mismatch.cli
+++ b/tests/v0-fail/complex_pattern_mismatch.cli
@@ -1,0 +1,5 @@
+#!/usr/bin/env clitest --v0
+
+$ echo "hello\nwe need a complex pattern mismatch here"
+! hello
+! w%{DATA} n%{DATA} a c%{DATA} p%{DATA} mm%{DATA} h%{DATA}

--- a/tests/v0-fail/complex_pattern_mismatch.cli
+++ b/tests/v0-fail/complex_pattern_mismatch.cli
@@ -1,5 +1,5 @@
 #!/usr/bin/env clitest --v0
 
-$ echo "hello\nwe need a complex pattern mismatch here"
+$ printf "hello\nwe need a complex pattern mismatch here\n"
 ! hello
 ! w%{DATA} n%{DATA} a c%{DATA} p%{DATA} mm%{DATA} h%{DATA}

--- a/tests/v0-fail/complex_pattern_mismatch.out
+++ b/tests/v0-fail/complex_pattern_mismatch.out
@@ -1,0 +1,17 @@
+Running <root>/complex_pattern_mismatch.cli ...
+
+echo "hello\nwe need a complex pattern mismatch here"
+---
+hello
+we need a complex pattern mismatch here
+---
+ERROR: pattern "w%{DATA} n%{DATA} a c%{DATA} p%{DATA} mm%{DATA} h%{DATA}" at line <root>/complex_pattern_mismatch.cli:5 does not match output line "we need a complex pattern mismatch here"
+[XX] missed sequence { ... }
+  [OK] matched "hello"
+  [XX] missed pattern "w%{DATA} n%{DATA} a c%{DATA} p%{DATA} mm%{DATA} h%{DATA}" != "we need a complex pattern mismatch here"
+
+❌ FAIL
+
+<root>/complex_pattern_mismatch.cli FAILED
+Error: pattern "w%{DATA} n%{DATA} a c%{DATA} p%{DATA} mm%{DATA} h%{DATA}" at line <root>/complex_pattern_mismatch.cli:5 does not match output line "we need a complex pattern mismatch here"
+

--- a/tests/v0-fail/complex_pattern_mismatch.out
+++ b/tests/v0-fail/complex_pattern_mismatch.out
@@ -1,6 +1,6 @@
 Running <root>/complex_pattern_mismatch.cli ...
 
-echo "hello\nwe need a complex pattern mismatch here"
+printf "hello\nwe need a complex pattern mismatch here\n"
 ---
 hello
 we need a complex pattern mismatch here

--- a/tests/v0-fail/ignore.out
+++ b/tests/v0-fail/ignore.out
@@ -5,7 +5,7 @@ printf "hello\nworld\n"
 hello
 world
 ---
-ERROR: pattern literal at line <root>/ignore.cli:7 does not match output line "world"
+ERROR: "goodbye" at line <root>/ignore.cli:7 does not match output line "world"
 [XX] missed sequence { ... }
   [OK]- matched "hello" (ignore)
   [XX]- missed "hello" != "world" (ignore)
@@ -14,5 +14,5 @@ ERROR: pattern literal at line <root>/ignore.cli:7 does not match output line "w
 ❌ FAIL
 
 <root>/ignore.cli FAILED
-Error: pattern literal at line <root>/ignore.cli:7 does not match output line "world"
+Error: "goodbye" at line <root>/ignore.cli:7 does not match output line "world"
 

--- a/tests/v0-fail/long_mismatch.out
+++ b/tests/v0-fail/long_mismatch.out
@@ -26,7 +26,7 @@ Excepteur sint occaecat cupidatat non
 proident, sunt in culpa qui officia
 deserunt mollit anim id est laborum.
 ---
-ERROR: pattern literal at line <root>/long_mismatch.cli:23 does not match output line "in reprehenderit in voluptate velit esseX"
+ERROR: "in reprehenderit in voluptate velit esse" at line <root>/long_mismatch.cli:23 does not match output line "in reprehenderit in voluptate velit esseX"
 [XX] missed sequence { ... }
   [OK] matched "Lorem ipsum dolor sit amet,"
   [OK] matched "consectetur adipiscing elit, sed do"
@@ -40,5 +40,5 @@ ERROR: pattern literal at line <root>/long_mismatch.cli:23 does not match output
 ❌ FAIL
 
 <root>/long_mismatch.cli FAILED
-Error: pattern literal at line <root>/long_mismatch.cli:23 does not match output line "in reprehenderit in voluptate velit esseX"
+Error: "in reprehenderit in voluptate velit esse" at line <root>/long_mismatch.cli:23 does not match output line "in reprehenderit in voluptate velit esseX"
 

--- a/tests/v0-fail/no_match.out
+++ b/tests/v0-fail/no_match.out
@@ -4,12 +4,12 @@ printf "hello\n"
 ---
 hello
 ---
-ERROR: pattern literal at line <root>/no_match.cli:4 does not match output line "hello"
+ERROR: "bye" at line <root>/no_match.cli:4 does not match output line "hello"
 [XX] missed sequence { ... }
   [XX] missed "bye" != "hello"
 
 ❌ FAIL
 
 <root>/no_match.cli FAILED
-Error: pattern literal at line <root>/no_match.cli:4 does not match output line "hello"
+Error: "bye" at line <root>/no_match.cli:4 does not match output line "hello"
 

--- a/tests/v0-fail/not.out
+++ b/tests/v0-fail/not.out
@@ -5,7 +5,7 @@ printf "goodbye\nworld\n"
 goodbye
 world
 ---
-ERROR: pattern not at line <root>/not.cli:4 does not match output line "goodbye"
+ERROR: not { ... } at line <root>/not.cli:4 does not match output line "goodbye"
 [XX] missed sequence { ... }
   [XX] missed not { ... }
     [OK] matched "goodbye"
@@ -13,5 +13,5 @@ ERROR: pattern not at line <root>/not.cli:4 does not match output line "goodbye"
 ❌ FAIL
 
 <root>/not.cli FAILED
-Error: pattern not at line <root>/not.cli:4 does not match output line "goodbye"
+Error: not { ... } at line <root>/not.cli:4 does not match output line "goodbye"
 

--- a/tests/v0-fail/optional.out
+++ b/tests/v0-fail/optional.out
@@ -4,7 +4,7 @@ printf "hello\n"
 ---
 hello
 ---
-ERROR: pattern literal at line <root>/optional.cli:7 does not match output line "<eof>"
+ERROR: "hello" at line <root>/optional.cli:7 does not match output
 [XX] missed sequence { ... }
   [OK] matched optional { ... }
     [OK] matched "hello"
@@ -13,5 +13,5 @@ ERROR: pattern literal at line <root>/optional.cli:7 does not match output line 
 ❌ FAIL
 
 <root>/optional.cli FAILED
-Error: pattern literal at line <root>/optional.cli:7 does not match output line "<eof>"
+Error: "hello" at line <root>/optional.cli:7 does not match output
 

--- a/tests/v0-fail/out_of_order.out
+++ b/tests/v0-fail/out_of_order.out
@@ -14,7 +14,7 @@ printf '{"name": "Alice"}\n{"name": "Mary"}\n{"name": "John"}\n'
 {"name": "Mary"}
 {"name": "John"}
 ---
-ERROR: pattern unordered at line <root>/out_of_order.cli:12 does not match output line "<eof>"
+ERROR: unordered { ... } at line <root>/out_of_order.cli:12 does not match output
 [XX] missed sequence { ... }
   [OK] matched "{\"name\": \"Alice\"}"
   [XX] missed unordered { ... }
@@ -25,5 +25,5 @@ ERROR: pattern unordered at line <root>/out_of_order.cli:12 does not match outpu
 ❌ FAIL
 
 <root>/out_of_order.cli FAILED
-Error: pattern unordered at line <root>/out_of_order.cli:12 does not match output line "<eof>"
+Error: unordered { ... } at line <root>/out_of_order.cli:12 does not match output
 

--- a/tests/v0-fail/reject.out
+++ b/tests/v0-fail/reject.out
@@ -4,7 +4,7 @@ printf "hello\n"
 ---
 hello
 ---
-ERROR: pattern reject at line <root>/reject.cli:5 rejected output line "hello"
+ERROR: reject at line <root>/reject.cli:5 rejected output line "hello"
 [XX] missed *
   [OK]- matched "hello" (ignore)
   [XX] missed <eof> != "hello"
@@ -13,5 +13,5 @@ ERROR: pattern reject at line <root>/reject.cli:5 rejected output line "hello"
 ❌ FAIL
 
 <root>/reject.cli FAILED
-Error: pattern reject at line <root>/reject.cli:5 rejected output line "hello"
+Error: reject at line <root>/reject.cli:5 rejected output line "hello"
 

--- a/tests/v0-fail/repeat.out
+++ b/tests/v0-fail/repeat.out
@@ -4,7 +4,7 @@ printf "hello\n"
 ---
 hello
 ---
-ERROR: pattern literal at line <root>/repeat.cli:5 does not match output line "hello"
+ERROR: "goodbye" at line <root>/repeat.cli:5 does not match output line "hello"
 [XX] missed sequence { ... }
   [XX] missed repeat { ... }
     [XX] missed "goodbye" != "hello"
@@ -12,5 +12,5 @@ ERROR: pattern literal at line <root>/repeat.cli:5 does not match output line "h
 ❌ FAIL
 
 <root>/repeat.cli FAILED
-Error: pattern literal at line <root>/repeat.cli:5 does not match output line "hello"
+Error: "goodbye" at line <root>/repeat.cli:5 does not match output line "hello"
 

--- a/tests/v0-fail/sequence.out
+++ b/tests/v0-fail/sequence.out
@@ -5,7 +5,7 @@ printf "b\na\n"
 b
 a
 ---
-ERROR: pattern literal at line <root>/sequence.cli:5 does not match output line "b"
+ERROR: "a" at line <root>/sequence.cli:5 does not match output line "b"
 [XX] missed sequence { ... }
   [XX] missed sequence { ... }
     [XX] missed "a" != "b"
@@ -13,5 +13,5 @@ ERROR: pattern literal at line <root>/sequence.cli:5 does not match output line 
 ❌ FAIL
 
 <root>/sequence.cli FAILED
-Error: pattern literal at line <root>/sequence.cli:5 does not match output line "b"
+Error: "a" at line <root>/sequence.cli:5 does not match output line "b"
 

--- a/tests/v0-fail/unordered.out
+++ b/tests/v0-fail/unordered.out
@@ -5,7 +5,7 @@ printf "a\nb\n"
 a
 b
 ---
-ERROR: pattern unordered at line <root>/unordered.cli:4 does not match output line "<eof>"
+ERROR: unordered { ... } at line <root>/unordered.cli:4 does not match output
 [XX] missed sequence { ... }
   [XX] missed unordered { ... }
     [OK] matched "a"
@@ -15,5 +15,5 @@ ERROR: pattern unordered at line <root>/unordered.cli:4 does not match output li
 ❌ FAIL
 
 <root>/unordered.cli FAILED
-Error: pattern unordered at line <root>/unordered.cli:4 does not match output line "<eof>"
+Error: unordered { ... } at line <root>/unordered.cli:4 does not match output
 

--- a/tests/v0-fail/unordered_complex_1.out
+++ b/tests/v0-fail/unordered_complex_1.out
@@ -10,7 +10,7 @@ u2bad
 u3
 repeat
 ---
-ERROR: pattern unordered at line <root>/unordered_complex_1.cli:4 does not match output line "u1"
+ERROR: unordered { ... } at line <root>/unordered_complex_1.cli:4 does not match output line "u1"
 [XX] missed sequence { ... }
   [XX] missed unordered { ... }
     [OK] matched sequence { ... }
@@ -27,5 +27,5 @@ ERROR: pattern unordered at line <root>/unordered_complex_1.cli:4 does not match
 ❌ FAIL
 
 <root>/unordered_complex_1.cli FAILED
-Error: pattern unordered at line <root>/unordered_complex_1.cli:4 does not match output line "u1"
+Error: unordered { ... } at line <root>/unordered_complex_1.cli:4 does not match output line "u1"
 

--- a/tests/v0-fail/unordered_complex_2.out
+++ b/tests/v0-fail/unordered_complex_2.out
@@ -10,7 +10,7 @@ repeat
 u2
 u3
 ---
-ERROR: pattern unordered at line <root>/unordered_complex_2.cli:4 does not match output line "u1"
+ERROR: unordered { ... } at line <root>/unordered_complex_2.cli:4 does not match output line "u1"
 [XX] missed sequence { ... }
   [XX] missed unordered { ... }
     [OK] matched sequence { ... }
@@ -27,5 +27,5 @@ ERROR: pattern unordered at line <root>/unordered_complex_2.cli:4 does not match
 ❌ FAIL
 
 <root>/unordered_complex_2.cli FAILED
-Error: pattern unordered at line <root>/unordered_complex_2.cli:4 does not match output line "u1"
+Error: unordered { ... } at line <root>/unordered_complex_2.cli:4 does not match output line "u1"
 

--- a/tests/v0-fail/unordered_complex_3.out
+++ b/tests/v0-fail/unordered_complex_3.out
@@ -13,7 +13,7 @@ u2
 u3
 repeat
 ---
-ERROR: pattern end at line <root>/unordered_complex_3.cli:3 does not match output line "repeat"
+ERROR: <eof> at line <root>/unordered_complex_3.cli:3 does not match output line "repeat"
 [XX] missed sequence { ... }
   [OK] matched unordered { ... }
     [OK] matched repeat { ... }
@@ -34,5 +34,5 @@ ERROR: pattern end at line <root>/unordered_complex_3.cli:3 does not match outpu
 ❌ FAIL
 
 <root>/unordered_complex_3.cli FAILED
-Error: pattern end at line <root>/unordered_complex_3.cli:3 does not match output line "repeat"
+Error: <eof> at line <root>/unordered_complex_3.cli:3 does not match output line "repeat"
 


### PR DESCRIPTION
Don't write out the escaped patterns on failure as they are very difficult to parse.