### PR TITLE
Fix for running bare files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-07-09
+
+### Fixed
+- `crok test.file` works and no longer prints "PWD does not exist".
+
 ## [0.8.0] - 2026-07-07
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = ["crates/*"]
+default-members = ["crates/crok", "crates/crok-integration", "crates/crok-lib"]
 
 [workspace.package]
 version = "0.8.1" # Update versions below as well

--- a/crates/crok-integration/src/testing.rs
+++ b/crates/crok-integration/src/testing.rs
@@ -39,7 +39,7 @@ pub fn load_test_scripts(pattern: Option<&str>) -> Vec<TestCase> {
             .flatten()
         {
             let test_name = test.file_name().to_str().unwrap().to_owned();
-            if !test_name.ends_with(".cli") {
+            if !test_name.ends_with(".cli") && !test_name.ends_with(".crok") {
                 continue;
             }
             if let Some(pattern) = pattern

--- a/crates/crok-lib/src/script.rs
+++ b/crates/crok-lib/src/script.rs
@@ -161,8 +161,15 @@ impl ScriptEnv {
             ]
         );
 
+        // Empty string -> current directory
+        let pwd = if pwd.as_ref().as_os_str().is_empty() {
+            Path::new(".")
+        } else {
+            pwd.as_ref()
+        };
+
         // Set the current working directory as a special variable "PWD"
-        let pwd = NicePathBuf::from(pwd.as_ref()).env_string();
+        let pwd = NicePathBuf::from(pwd).env_string();
         self.env_vars.insert("PWD".to_string(), pwd);
         // Save the initial PWD as INITIAL_PWD so it can easily be restored
         self.env_vars
@@ -587,7 +594,10 @@ impl ScriptKillSender {
 impl ScriptRunContext {
     pub fn new(args: ScriptRunArgs, script_path: impl AsRef<Path>, output: ScriptOutput) -> Self {
         let mut env = ScriptEnv::default();
-        env.set_defaults(script_path.as_ref().parent().unwrap());
+
+        // `Path::parent()` returns `Some("")` for a bare filename (e.g. `test.crok`)
+        let script_parent = script_path.as_ref().parent().unwrap_or(Path::new(""));
+        env.set_defaults(script_parent);
 
         let kill = Arc::new(AtomicBool::new(false));
 

--- a/tests/self-test/bare_file.crok
+++ b/tests/self-test/bare_file.crok
@@ -1,0 +1,18 @@
+#!/usr/bin/env crok --v0
+# A bare file should work (and not print "PWD does not exist")
+
+reject {
+    ? .*PWD.*
+}
+
+$ cargo run --quiet -- data/hello_world.crok
+*
+! Hello, World!
+*
+
+cd "data";
+
+$ cargo run --quiet -- hello_world.crok
+*
+! Hello, World!
+*

--- a/tests/self-test/data/hello_world.crok
+++ b/tests/self-test/data/hello_world.crok
@@ -1,0 +1,3 @@
+#!/usr/bin/env crok --v0
+$ printf "Hello, World!\n"
+! Hello, World!


### PR DESCRIPTION
Fixes "PWD does not exist" when running `crok bare-file.crok`