### PR TITLE
Allow override of TARGET_* vars, package up env vars with remote scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.0 - 2026-08-09
+
+### Added
+
+- `--target-os`/`--target-family`/`--target-arch` override the compile-time
+  `TARGET_*` values, so a host-side crok can evaluate scripts for a remote
+  target it drives via `--runner`.
+- With `--runner`, script-set vars are inlined into the command as
+  `env K='v' ... sh -c '...'`, so runners that cross a process or host
+  boundary (ssh, docker exec) deliver them.
+
 ## [0.8.3] - 2026-07-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clitest"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "crok",
 ]
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "crok"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "clap",
  "crok-lib",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "crok-lib"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "derive-io",
  "derive_more",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "procstream"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "libc",
  "tlhelp32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,12 +4,12 @@ members = ["crates/*"]
 default-members = ["crates/crok", "crates/crok-integration", "crates/crok-lib", "crates/procstream"]
 
 [workspace.package]
-version = "0.8.3" # Update versions below as well
+version = "0.9.0" # Update versions below as well
 
 [workspace.dependencies]
-crok = { path = "crates/crok", version = "0.8.3" }
-crok-lib = { path = "crates/crok-lib", version = "0.8.3" }
-procstream = { path = "crates/procstream", version = "0.8.3" }
+crok = { path = "crates/crok", version = "0.9.0" }
+crok-lib = { path = "crates/crok-lib", version = "0.9.0" }
+procstream = { path = "crates/procstream", version = "0.9.0" }
 
 clap = "4.6.1"
 derive-io = "=0.5.0"

--- a/crates/crok-lib/src/command.rs
+++ b/crates/crok-lib/src/command.rs
@@ -95,13 +95,16 @@ impl CommandLine {
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
             let mut cmd = Command::new(&bits[0]);
             cmd.args(&bits[1..]);
+            // A runner may cross a process or host boundary (ssh, docker exec)
+            // where our environment doesn't follow so we inline them.
+            cmd.arg(inline_env_command(&self.command, envs));
             cmd
         } else {
             let mut cmd = Command::new("sh");
             cmd.arg("-c");
+            cmd.arg(&self.command);
             cmd
         };
-        command.arg(&self.command);
         command.envs(envs);
         if let Some(pwd) = envs.get("PWD") {
             command.current_dir(pwd);
@@ -201,5 +204,139 @@ impl CommandLine {
             }
             other => other,
         }
+    }
+}
+
+/// Vars crok manages itself: PWD/INITIAL_PWD drive the runner's working
+/// directory, and TARGET_* exist for script conditionals, not for commands.
+const SPECIAL_VARS: &[&str] = &[
+    "PWD",
+    "INITIAL_PWD",
+    "TARGET_OS",
+    "TARGET_FAMILY",
+    "TARGET_ARCH",
+];
+
+/// Rewrite `command` as `env K='v' ... sh -c 'command'` so a runner that crosses a
+/// process or host boundary still delivers them.
+fn inline_env_command(command: &str, envs: &HashMap<String, String>) -> String {
+    let mut vars: Vec<_> = envs
+        .iter()
+        .filter(|(k, _)| !SPECIAL_VARS.contains(&k.as_str()))
+        .collect();
+    if vars.is_empty() {
+        return command.to_string();
+    }
+    vars.sort();
+
+    let mut out = String::from("env");
+    for (key, value) in vars {
+        out.push(' ');
+        out.push_str(key);
+        out.push('=');
+        out.push_str(&sh_quote(value));
+    }
+    // Wrap in `sh -c` so the env applies to the whole command, not just the
+    // first segment of a pipe or `&&` chain.
+    out.push_str(" sh -c ");
+    out.push_str(&sh_quote(command));
+    out
+}
+
+/// POSIX quoting: keep the generated command printable.
+fn sh_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    // Current single-quoted run, opened lazily so control-char splices sit
+    // between runs rather than inside one.
+    let mut open = false;
+    for c in s.chars() {
+        if c.is_ascii_control() && c != '\n' || c == '\x7f' {
+            if open {
+                out.push('\'');
+                open = false;
+            }
+            out.push_str(&format!("\"$(printf '\\{:03o}')\"", c as u32));
+        } else {
+            if !open {
+                out.push('\'');
+                open = true;
+            }
+            if c == '\'' {
+                out.push_str("'\\''");
+            } else {
+                out.push(c);
+            }
+        }
+    }
+    if open {
+        out.push('\'');
+    }
+    if out.is_empty() {
+        out.push_str("''");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sh_quote() {
+        assert_eq!(sh_quote("plain"), "'plain'");
+        assert_eq!(sh_quote(""), "''");
+        assert_eq!(sh_quote("a b $c `d`"), "'a b $c `d`'");
+        assert_eq!(sh_quote("it's"), r#"'it'\''s'"#);
+    }
+
+    #[test]
+    fn test_sh_quote_control_chars() {
+        assert_eq!(sh_quote("a\x01b"), r#"'a'"$(printf '\001')"'b'"#);
+        assert_eq!(sh_quote("\x1b"), r#""$(printf '\033')""#);
+        assert_eq!(sh_quote("a\tb"), r#"'a'"$(printf '\011')"'b'"#);
+        assert_eq!(sh_quote("\x7f"), r#""$(printf '\177')""#);
+        // Newline stays literal: $(printf '\n') would strip it as a trailing
+        // newline of the substitution.
+        assert_eq!(sh_quote("a\nb"), "'a\nb'");
+        // Quote directly after a control splice.
+        assert_eq!(sh_quote("\x01'x"), r#""$(printf '\001')"''\''x'"#);
+    }
+
+    /// The generated splices must round-trip through a real shell.
+    #[test]
+    #[cfg(unix)]
+    fn test_sh_quote_shell_roundtrip() {
+        for value in ["plain", "it's", "a\x01b", "a\nb", "\x1b[1m", "a\tb'\x02"] {
+            let out = std::process::Command::new("sh")
+                .arg("-c")
+                .arg(format!("printf %s {}", sh_quote(value)))
+                .output()
+                .unwrap();
+            assert_eq!(
+                String::from_utf8_lossy(&out.stdout),
+                value,
+                "round-trip failed for {value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_inline_env_command_empty() {
+        let envs = HashMap::from([("PWD".to_string(), "/tmp".to_string())]);
+        assert_eq!(inline_env_command("echo hi", &envs), "echo hi");
+    }
+
+    #[test]
+    fn test_inline_env_command() {
+        let envs = HashMap::from([
+            ("PWD".to_string(), "/tmp".to_string()),
+            ("TARGET_OS".to_string(), "freebsd".to_string()),
+            ("RUSTFLAGS".to_string(), "-C opt-level=1".to_string()),
+            ("B".to_string(), "it's".to_string()),
+        ]);
+        assert_eq!(
+            inline_env_command("cargo build && cargo test", &envs),
+            r#"env B='it'\''s' RUSTFLAGS='-C opt-level=1' sh -c 'cargo build && cargo test'"#
+        );
     }
 }

--- a/crates/crok-lib/src/script.rs
+++ b/crates/crok-lib/src/script.rs
@@ -84,6 +84,12 @@ pub struct ScriptRunArgs {
     pub simplified_output: bool,
     pub show_line_numbers: bool,
     pub runner: Option<String>,
+    /// Override the compile-time TARGET_OS.
+    pub target_os: Option<String>,
+    /// Override the compile-time TARGET_FAMILY.
+    pub target_family: Option<String>,
+    /// Override the compile-time TARGET_ARCH.
+    pub target_arch: Option<String>,
     pub quiet: bool,
     pub verbose: bool,
     pub global_timeout: Option<Duration>,
@@ -598,6 +604,16 @@ impl ScriptRunContext {
         // `Path::parent()` returns `Some("")` for a bare filename (e.g. `test.crok`)
         let script_parent = script_path.as_ref().parent().unwrap_or(Path::new(""));
         env.set_defaults(script_parent);
+
+        for (var, value) in [
+            ("TARGET_OS", &args.target_os),
+            ("TARGET_FAMILY", &args.target_family),
+            ("TARGET_ARCH", &args.target_arch),
+        ] {
+            if let Some(value) = value {
+                env.set_env(var, value);
+            }
+        }
 
         let kill = Arc::new(AtomicBool::new(false));
 

--- a/crates/crok/src/lib.rs
+++ b/crates/crok/src/lib.rs
@@ -85,6 +85,18 @@ struct Args {
     #[arg(long)]
     runner: Option<String>,
 
+    /// Override TARGET_OS.
+    #[arg(long)]
+    target_os: Option<String>,
+
+    /// Override TARGET_FAMILY.
+    #[arg(long)]
+    target_family: Option<String>,
+
+    /// Override TARGET_ARCH.
+    #[arg(long)]
+    target_arch: Option<String>,
+
     /// Dump the script to JSON or TOML.
     #[arg(long)]
     dump: Option<DumpFormat>,
@@ -158,6 +170,9 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
             ignore_exit_codes: args.ignore_exit_codes,
             ignore_matches: args.ignore_matches,
             runner: args.runner.clone(),
+            target_os: args.target_os.clone(),
+            target_family: args.target_family.clone(),
+            target_arch: args.target_arch.clone(),
             show_line_numbers: args.show_line_numbers,
             quiet: args.quiet,
             no_color: false,


### PR DESCRIPTION
Some remote --runner fixes:

 - Allow TARGET_* vars to be overridden so you can test as if you were running in the remote OS
 - `--runner` invocations have env vars stuffed into them so they can cross process boundaries.